### PR TITLE
Allow pre-filled calculator values via URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Et simpelt statisk website med en prisberegner til 3D‑print. Siden giver infor
 ## Sådan bruges siden
 1. Åbn `yding3dprint.htm` i en moderne webbrowser.
 2. Indtast dit forventede filamentforbrug og printtid.
+   - Alternativt kan felterne forudfyldes via URL'en, f.eks. `yding3dprint.htm?filament=50&printtid=2`.
 3. Klik på **Beregn Pris** for at se den beregnede pris.
 
 ## Udvikling

--- a/yding3dprint.htm
+++ b/yding3dprint.htm
@@ -130,6 +130,24 @@
             
             document.getElementById('result').innerHTML = `🛒 Din pris: <strong>${endeligPris.toFixed(2)} DKK</strong>`;
         }
+
+        function prefillFraQuery() {
+            const params = new URLSearchParams(window.location.search);
+            const filamentParam = params.get('filament');
+            const timeParam = params.get('printtid') || params.get('timer');
+
+            if (filamentParam !== null) {
+                document.getElementById('filament').value = filamentParam;
+            }
+            if (timeParam !== null) {
+                document.getElementById('printtid').value = timeParam;
+            }
+            if (filamentParam !== null || timeParam !== null) {
+                beregnPris();
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', prefillFraQuery);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Parse `filament` and `printtid` query params to prefill calculator inputs and auto-calc price
- Document URL-based pre-filling in README

## Testing
- `npx --yes htmlhint yding3dprint.htm`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ac92fa84832e858c00b238928b91