### PR TITLE
Add name query support and rename HTML to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ Dette repository indeholder koden til [yding3dprint.dk](https://yding3dprint.dk)
 Et simpelt statisk website med en prisberegner til 3D‑print. Siden giver information om Yding 3D Print og beregner en estimeret pris baseret på materialeforbrug og printtid.
 
 ## Sådan bruges siden
-1. Åbn `yding3dprint.htm` i en moderne webbrowser.
+1. Åbn `index.html` i en moderne webbrowser.
 2. Indtast dit forventede filamentforbrug og printtid.
-   - Alternativt kan felterne forudfyldes via URL'en, f.eks. `yding3dprint.htm?filament=50&printtid=2`.
+   - Alternativt kan felterne forudfyldes via URL'en, f.eks. `index.html?filament=50&printtid=2&navn=Testprint`.
 3. Klik på **Beregn Pris** for at se den beregnede pris.
 
 ## Udvikling
 Koden kan valideres med [HTMLHint](https://github.com/htmlhint/HTMLHint):
 
 ```bash
-npx --yes htmlhint yding3dprint.htm
+npx --yes htmlhint index.html
 ```
 
 Ændringer til filerne bør committes via git.

--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
         <p>💬 <strong>Jeg foretrækker, at du skriver til mig på Facebook Messenger:</strong> <a href="https://www.facebook.com/messages/t/580122692" target="_blank">Send en besked her</a></p>
         
         <h2>💡 Prisberegning</h2>
+        <p id="navnDisplay"></p>
         <p>Indtast dit filamentforbrug og printtid for at se din pris.</p>
         
         <label>Filamentforbrug (g):</label>
@@ -112,6 +113,8 @@
     </div>
     
     <script>
+        let printNavn = '';
+
         function beregnPris() {
             let filament = parseFloat(document.getElementById('filament').value) || 0;
             let printtid = parseFloat(document.getElementById('printtid').value) || 0;
@@ -127,20 +130,26 @@
             let totalOmkostning = filamentOmkostning + stromOmkostning;
             let salgsPris = totalOmkostning * markup;
             let endeligPris = Math.max(salgsPris, minPris);
-            
-            document.getElementById('result').innerHTML = `🛒 Din pris: <strong>${endeligPris.toFixed(2)} DKK</strong>`;
+
+            const navnTekst = printNavn ? ` for <strong>${printNavn}</strong>` : '';
+            document.getElementById('result').innerHTML = `🛒 Din pris${navnTekst}: <strong>${endeligPris.toFixed(2)} DKK</strong>`;
         }
 
         function prefillFraQuery() {
             const params = new URLSearchParams(window.location.search);
             const filamentParam = params.get('filament');
             const timeParam = params.get('printtid') || params.get('timer');
+            const navnParam = params.get('navn') || params.get('name');
 
             if (filamentParam !== null) {
                 document.getElementById('filament').value = filamentParam;
             }
             if (timeParam !== null) {
                 document.getElementById('printtid').value = timeParam;
+            }
+            if (navnParam !== null) {
+                printNavn = navnParam;
+                document.getElementById('navnDisplay').innerHTML = `Prisestimat for: <strong>${printNavn}</strong>`;
             }
             if (filamentParam !== null || timeParam !== null) {
                 beregnPris();


### PR DESCRIPTION
## Summary
- rename main HTML page to `index.html`
- support a `navn`/`name` query parameter and show the name in price estimates
- document new entry point and query usage

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7b0314480832e8293085a9f26ed45