### PR TITLE
Use company name instead of plural pronouns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dette repository indeholder koden til [yding3dprint.dk](https://yding3dprint.dk). Koden er gjort offentligt for at sikre fuld transparens omkring priser og beregninger.
 
-Et simpelt statisk website med en prisberegner til 3D‑print. Siden giver information om Yding 3D Print og beregner en estimeret pris baseret på materialeforbrug og printtid.
+Et simpelt statisk website med en prisberegner til 3D print. Siden giver information om Yding 3D Print og beregner en estimeret pris baseret på materialeforbrug og printtid.
 
 ## Sådan bruges siden
 1. Åbn `index.html` i en moderne webbrowser.

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 <body>
     <div class="container">
         <h1>🖨️ Yding 3D Print</h1>
-        <h3>💡 Jeg købte en 3D-printer og har printet i mange timer – nu har jeg ledig kapacitet til at tage ordrer for vores lokale community. Hvis du ikke har knowhow, økonomi eller mulighed for at printe selv, så hjælper jeg gerne! 🎉</h3>
+        <h3>💡 Jeg købte en 3D printer og har printet i mange timer – nu har jeg ledig kapacitet til at tage ordrer for det lokale community. Hvis du ikke har knowhow, økonomi eller mulighed for at printe selv, så hjælper jeg gerne! 🎉</h3>
         <p>📍 Yding Toft 8B, 8752 Østbirk</p>
         <p>📞 Kontakt: steffen@sbrandsborg.dk</p>
         <p>🔢 CVR: 42002984</p>
@@ -82,10 +82,10 @@
         <div class="result" id="result"></div>
         
         <div class="info-box">
-            <h2>💰 Prisberegner for 3D-print</h2>
-            <p>Hos Yding 3D Print beregner vi prisen for dine 3D-print baseret på materialeforbrug og printtid. Vi ønsker at være 100% gennemsigtige om vores prissætning, så her kan du se præcis, hvordan vi beregner din pris.</p>
+            <h2>💰 Prisberegner for 3D print</h2>
+            <p>Hos Yding 3D Print beregner firmaet prisen for dine 3D print baseret på materialeforbrug og printtid. Yding 3D Print ønsker at være 100% gennemsigtig om prissætningen, så her kan du se præcis, hvordan prisen beregnes.</p>
             <ul>
-                <li>🧵 <strong>Filament:</strong> Vi bruger som standard PLA, PLA Matte og PETG-HF.</li>
+                <li>🧵 <strong>Filament:</strong> Yding 3D Print bruger som standard PLA, PLA Matte og PETG-HF.</li>
                 <li>💰 <strong>Filamentpris:</strong> 180,25 DKK/kg (0,18025 DKK/g)</li>
                 <li>⚡ <strong>Strømpris:</strong> 3,00 DKK/kWh</li>
                 <li>🔌 <strong>Printerforbrug:</strong> 100W (0,1 kW) under print</li>


### PR DESCRIPTION
## Summary
- replace plural references with "Yding 3D Print" and adjust copy accordingly
- remove unnecessary hyphenation in website and README

## Testing
- `npx --yes htmlhint index.html`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b1b15ed8832eaf1c67b3224e6c69