### PR TITLE
Add dark mode with system and manual toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,34 +5,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Yding 3D Print - Priser & Beregner</title>
     <style>
+        :root {
+            --bg-color: #f4f4f4;
+            --text-color: #333;
+            --container-bg: #ffffff;
+            --input-bg: #ffffff;
+            --input-color: #000000;
+            --input-border: #cccccc;
+            --button-bg: #28a745;
+            --button-hover-bg: #218838;
+            --info-bg: #fff3cd;
+            --info-border: #ffa000;
+        }
+
         body {
             font-family: Arial, sans-serif;
             margin: 0;
             padding: 0;
-            background-color: #f4f4f4;
+            background-color: var(--bg-color);
+            color: var(--text-color);
             text-align: center;
         }
+
         .container {
             max-width: 800px;
             margin: 40px auto;
             padding: 20px;
-            background: white;
+            background: var(--container-bg);
             border-radius: 10px;
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
         }
-        h1, h2, h3 {
-            color: #333;
+
+        h1,
+        h2,
+        h3 {
+            color: var(--text-color);
         }
+
         input {
             width: 100%;
             padding: 10px;
             margin: 10px 0;
-            border: 1px solid #ccc;
+            border: 1px solid var(--input-border);
             border-radius: 5px;
             font-size: 16px;
+            background-color: var(--input-bg);
+            color: var(--input-color);
         }
+
         button {
-            background: #28a745;
+            background: var(--button-bg);
             color: white;
             padding: 10px;
             border: none;
@@ -40,25 +62,46 @@
             font-size: 18px;
             cursor: pointer;
         }
+
         button:hover {
-            background: #218838;
+            background: var(--button-hover-bg);
         }
+
+        .theme-toggle {
+            float: right;
+        }
+
         .result {
             margin-top: 20px;
             font-size: 18px;
             font-weight: bold;
         }
+
         .info-box {
             margin-top: 20px;
             padding: 20px;
-            background: #fff3cd;
-            border-left: 5px solid #ffa000;
+            background: var(--info-bg);
+            border-left: 5px solid var(--info-border);
             text-align: left;
+        }
+
+        body.dark {
+            --bg-color: #121212;
+            --text-color: #eeeeee;
+            --container-bg: #1e1e1e;
+            --input-bg: #333333;
+            --input-color: #eeeeee;
+            --input-border: #555555;
+            --button-bg: #3a9d64;
+            --button-hover-bg: #2d7d51;
+            --info-bg: #333333;
+            --info-border: #ffa000;
         }
     </style>
 </head>
 <body>
     <div class="container">
+        <button id="themeToggle" class="theme-toggle"></button>
         <h1>🖨️ Yding 3D Print</h1>
         <h3>💡 Jeg købte en 3D printer og har printet i mange timer – nu har jeg ledig kapacitet til at tage ordrer for det lokale community. Hvis du ikke har knowhow, økonomi eller mulighed for at printe selv, så hjælper jeg gerne! 🎉</h3>
         <p>📍 Yding Toft 8B, 8752 Østbirk</p>
@@ -115,6 +158,33 @@
     <script>
         let printNavn = '';
 
+        const themeToggle = document.getElementById('themeToggle');
+
+        function applyTheme(theme) {
+            document.body.classList.toggle('dark', theme === 'dark');
+        }
+
+        function updateToggleText() {
+            themeToggle.textContent = document.body.classList.contains('dark') ? '☀️' : '🌙';
+        }
+
+        function initTheme() {
+            const storedTheme = localStorage.getItem('theme');
+            if (storedTheme) {
+                applyTheme(storedTheme);
+            } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                applyTheme('dark');
+            }
+            updateToggleText();
+        }
+
+        themeToggle.addEventListener('click', () => {
+            const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+            updateToggleText();
+        });
+
         function beregnPris() {
             let filament = parseFloat(document.getElementById('filament').value) || 0;
             let printtid = parseFloat(document.getElementById('printtid').value) || 0;
@@ -156,7 +226,10 @@
             }
         }
 
-        document.addEventListener('DOMContentLoaded', prefillFraQuery);
+        document.addEventListener('DOMContentLoaded', () => {
+            initTheme();
+            prefillFraQuery();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce CSS variables and dark theme styles with automatic detection via prefers-color-scheme
- Add theme toggle button storing preference in localStorage
- Update scripts to initialize theme and handle manual switching

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7b6e0506c832ebc2ba72ab7313f85