### PR TITLE
Add printing disclaimer and Instagram link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ npx --yes htmlhint index.html
 
 Ændringer til filerne bør committes via git.
 
+## Disclaimer
+3D print er opbygget af mange lag, og der kan derfor forekomme små overfladefejl. Resultatet er næsten altid perfekt, men meget komplekse modeller kan ændre det endelige resultat. Hvis Yding 3D Print vurderer, at printet er i dårlig stand, laves der naturligvis et nyt uden beregning.
+
+## Links
+- [Instagram](https://www.instagram.com/yding3dprint/)
+

--- a/index.html
+++ b/index.html
@@ -109,7 +109,8 @@
         <p>🔢 CVR: 42002984</p>
         <p>💰 MobilePay Box: <strong>8125HG</strong></p>
         <p>💬 <strong>Jeg foretrækker, at du skriver til mig på Facebook Messenger:</strong> <a href="https://www.facebook.com/messages/t/580122692" target="_blank">Send en besked her</a></p>
-        
+        <p>🔗 Links: <a href="https://www.instagram.com/yding3dprint/" target="_blank">Instagram</a></p>
+
         <h2>💡 Prisberegning</h2>
         <p id="navnDisplay"></p>
         <p>Indtast dit filamentforbrug og printtid for at se din pris.</p>
@@ -152,6 +153,11 @@
                 <li><strong>Total omkostning:</strong> 9,61 DKK</li>
                 <li><strong>Salgspris:</strong> 9,61 × 3 = 28,83 DKK (justeres til 30 DKK, da det er minimumsprisen).</li>
             </ul>
+        </div>
+
+        <div class="info-box">
+            <h3>ℹ️ Disclaimer</h3>
+            <p>3D print er opbygget af mange lag, og der kan derfor forekomme små overfladefejl. Resultatet er næsten altid perfekt, men meget komplekse modeller kan ændre det endelige resultat. Hvis jeg, Yding 3D Print, vurderer at printet er i dårlig stand, bliver det naturligvis printet om uden beregning.</p>
         </div>
     </div>
     


### PR DESCRIPTION
## Summary
- move Instagram link to standalone links line and remove mention from disclaimer
- document Instagram under new links section in README

## Testing
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7bb3e0368832ea3ed086d5a11e356