### PR TITLE
Improve social media icons and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,16 +128,29 @@
         <p>📞 Kontakt: steffen@sbrandsborg.dk</p>
         <p>🔢 CVR: 42002984</p>
         <p>💰 MobilePay Box: <strong>8125HG</strong></p>
-        <p>💬 <strong>Jeg foretrækker, at du skriver til mig på Facebook Messenger:</strong>
-            <a href="https://www.facebook.com/messages/t/580122692" target="_blank">
-                <img src="https://upload.wikimedia.org/wikipedia/commons/4/42/Facebook_Messenger_logo_2020.svg" alt="Messenger" class="icon">Send en besked her
-            </a>
-        </p>
-        <p>🔗 Links:
-            <a href="https://www.instagram.com/yding3dprint/" target="_blank">
-                <img src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png" alt="Instagram" class="icon">Instagram
-            </a>
-        </p>
+          <p>💬 <strong>Jeg foretrækker, at du skriver til mig på Facebook Messenger:</strong>
+              <a href="https://www.facebook.com/messages/t/580122692" target="_blank">
+                  <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                      <title>Messenger</title>
+                      <path d="M12 0C5.37 0 0 4.98 0 11.11c0 3.5 1.67 6.6 4.28 8.62v4.27l3.9-2.14c1.15.32 2.38.49 3.82.49 6.63 0 12-4.98 12-11.11S18.63 0 12 0zm1.19 14.94l-3.2-3.43-6.22 3.43 6.66-7.08 3.25 3.43 6.18-3.43-6.67 7.08z"/>
+                  </svg>
+                  Send en besked her
+              </a>
+          </p>
+          <p>🔗 Links:
+              <a href="https://www.instagram.com/yding3dprint/" target="_blank" aria-label="Instagram">
+                  <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                      <title>Instagram</title>
+                      <path d="M7 2C4.2 2 2 4.2 2 7v10c0 2.8 2.2 5 5 5h10c2.8 0 5-2.2 5-5V7c0-2.8-2.2-5-5-5H7zm10 2c1.7 0 3 1.3 3 3v10c0 1.7-1.3 3-3 3H7c-1.7 0-3-1.3-3-3V7c0-1.7 1.3-3 3-3h10zm-5 3.5A4.5 4.5 0 1 0 16.5 12 4.5 4.5 0 0 0 12 7.5zm0 7A2.5 2.5 0 1 1 14.5 12 2.5 2.5 0 0 1 12 14.5zm4.8-7.7a1 1 0 1 1-1-1 1 1 0 0 1 1 1z"/>
+                  </svg>
+              </a>
+              <a href="https://www.facebook.com/messages/t/580122692" target="_blank" aria-label="Messenger">
+                  <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                      <title>Messenger</title>
+                      <path d="M12 0C5.37 0 0 4.98 0 11.11c0 3.5 1.67 6.6 4.28 8.62v4.27l3.9-2.14c1.15.32 2.38.49 3.82.49 6.63 0 12-4.98 12-11.11S18.63 0 12 0zm1.19 14.94l-3.2-3.43-6.22 3.43 6.66-7.08 3.25 3.43 6.18-3.43-6.67 7.08z"/>
+                  </svg>
+              </a>
+          </p>
 
         <h2>💡 Prisberegning</h2>
         <p id="navnDisplay"></p>


### PR DESCRIPTION
## Summary
- show messenger icon using inline SVG for consistent display
- remove Instagram label and add messenger icon link
- add aria labels and titles for better accessibility

## Testing
- `html5validator index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c7d49036cc832ebf762a7bbcd0a5ae