### PR TITLE
Vis/Skjul 'Valgfri pris-overstyring' med toggle-knap

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,28 +158,37 @@
         placeholder="Indtast printtid i timer"
       />
 
-      <h3>Valgfri pris-overstyring</h3>
-      <p>
-        Indtast kun disse felter, hvis du vil overstyre standardpriserne for
-        filament eller strøm.
-      </p>
-      <label>Filamentpris (DKK/kg):</label>
-      <input
-        type="number"
-        id="filamentPris"
-        placeholder="Standard: 180,25 DKK/kg"
-        step="0.01"
-        min="0"
-      />
+      <button
+        type="button"
+        id="overrideToggle"
+        onclick="togglePrisOverstyring()"
+      >
+        Vis valgfri pris-overstyring
+      </button>
+      <div id="prisOverstyring" hidden>
+        <h3>Valgfri pris-overstyring</h3>
+        <p>
+          Indtast kun disse felter, hvis du vil overstyre standardpriserne for
+          filament eller strøm.
+        </p>
+        <label>Filamentpris (DKK/kg):</label>
+        <input
+          type="number"
+          id="filamentPris"
+          placeholder="Standard: 180,25 DKK/kg"
+          step="0.01"
+          min="0"
+        />
 
-      <label>Strømpris (DKK/kWh):</label>
-      <input
-        type="number"
-        id="stromPris"
-        placeholder="Standard: 3,00 DKK/kWh"
-        step="0.01"
-        min="0"
-      />
+        <label>Strømpris (DKK/kWh):</label>
+        <input
+          type="number"
+          id="stromPris"
+          placeholder="Standard: 3,00 DKK/kWh"
+          step="0.01"
+          min="0"
+        />
+      </div>
 
       <button onclick="beregnPris()">Beregn Pris</button>
       <button type="button" id="specToggle" onclick="toggleSpecifikation()">
@@ -381,6 +390,19 @@
         } else {
           box.setAttribute("hidden", "");
           toggleButton.textContent = "Vis pris-specifikation";
+        }
+      }
+
+      function togglePrisOverstyring() {
+        const box = document.getElementById("prisOverstyring");
+        const toggleButton = document.getElementById("overrideToggle");
+        const isHidden = box.hasAttribute("hidden");
+        if (isHidden) {
+          box.removeAttribute("hidden");
+          toggleButton.textContent = "Skjul valgfri pris-overstyring";
+        } else {
+          box.setAttribute("hidden", "");
+          toggleButton.textContent = "Vis valgfri pris-overstyring";
         }
       }
 


### PR DESCRIPTION
### Motivation
- Skjule de valgfrie pris-overstyringsfelter bag en knap, så UI er mindre rodet og sektionen kun vises ved brugerens valg.
- Matche adfærden for pris-specifikation, som allerede vises via en toggle-knap.

### Description
- Tilføjet en knap med id `overrideToggle` som viser/nylter sektionen for pris-overstyring når den klikkes.
- Flyttet de eksisterende inputfelter til en wrapper `<div id="prisOverstyring" hidden>` så de er skjult som standard.
- Implementeret `togglePrisOverstyring()` JavaScript-funktion der toggler `hidden`-attributten og opdaterer knapteksten.
- Ingen ændringer i prisberegningslogikken er foretaget; kun layout og visningslogik blev ændret.

### Testing
- Startet lokal server med `python -m http.server 8000` for at serve `index.html`, hvilket returnerede HTTP 200 OK.
- Kørte en Playwright-script der åbnede `index.html`, klikkede på `#overrideToggle` og tog et screenshot for at verificere visning, som lykkedes (screenshot artefakt genereret).
- Flere tidligere Playwright-kørsler timed out under debugging, men den endelige kørsel lykkedes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953cebc5fd4832eaf5ecae012be7891)